### PR TITLE
feat: add state/tool context management to live api

### DIFF
--- a/gemini_live_boilerplate/server/tool_context.py
+++ b/gemini_live_boilerplate/server/tool_context.py
@@ -1,0 +1,85 @@
+"""Manages state for agent and tools throughout the session"""
+from typing import Optional, Dict, Any
+
+class ToolContext:
+    """Manages state and tool context for tools within a session
+    This class provides a simple and safe interface for tools to read, write,
+    and delete data related to the current session, enabling stateful
+    multi-turn interactions.
+    """
+    def __init__(self,
+                 session_id: str,
+                 initial_state: Optional[Dict[str, Any]] = None):
+        """Initialize the context
+        Args:
+            session_id: A unique identifier for the current session.
+            initial_state: An optional dictionary to pre-populate the state.
+        """
+        self.session_id = session_id
+        if initial_state:
+            self._state = initial_state.copy()
+        else:
+            self._state = {}
+    
+    def dump_state(self) -> Dict[str, Any]:
+        """
+        Returns a copy of the entire state dictionary.
+        Returns:
+            A shallow copy of the internal state dictionary, preventing direct mutation.
+        """
+        return self._state.copy()
+
+    def get(self,
+            key: str,
+            default: Optional[Any] = None) -> Any:
+        """
+        Retrieves the value of a key from the state.
+
+        Args:
+            key: The key of the value to retrieve.
+            default: The value to return if the key is not found.
+
+        Returns:
+            The value associated with the key, or the default value if not found.
+        """
+
+        return self._state.get(key, default)
+    
+    def update(self, **kwargs) -> Dict[str, Any]:
+        """
+        Updates the state with one or more key-value pairs.
+        Overwrites keys if they are already present.
+
+        Args:
+            **kwargs: Arbitrary keyword arguments to add or update in the state.
+
+        Returns:
+            The instance of the class to allow for method chaining (e.g., context.update(...).update(...))
+
+        Usage:
+            updated_data = ctx.update(key1=value1, key2=value2...)
+            or
+            data_to_update = {"key1": "value1", "key2": "value2"}
+            updated_data = ctx.update(**data_to_update)
+        """
+        self._state.update(kwargs)
+        return self._state.copy()
+    
+    def delete(self, key: str) -> bool:
+        """
+        Deletes a key-value pair from the state if it exists.
+
+        Args:
+            key: The key to delete from the state.
+        
+        Returns:
+            True if the key was found and deleted, False otherwise.
+        """
+        if key in self._state:
+            del self._state[key]
+            return True
+        return False
+    
+    def clear(self) -> None:
+        """Clears the entire state, resetting it to an empty dictionary."""
+        self._state = {}

--- a/gemini_live_boilerplate/server/tools.py
+++ b/gemini_live_boilerplate/server/tools.py
@@ -2,8 +2,10 @@
 # pylint: disable=line-too-long
 from enum import Enum
 from typing import Optional, Annotated
+import uuid
 import datetime
 from utils import function_tool # pylint: disable=no-name-in-module
+from tool_context import ToolContext # pylint: disable=no-name-in-module
 
 class MeetingRoom(Enum):
     """Enum class for meeting room"""
@@ -13,30 +15,50 @@ class MeetingRoom(Enum):
 
 @function_tool
 def schedule_meet_tool(
+    tool_ctx: ToolContext,
     attendees: Annotated[list[str], "List of the people attending the meeting"],
     topic: Annotated[str, "The subject or the topic of the meeting"],
     date: Annotated[str, "The date of the meeting (e.g., 25/06/2025)"],
     meeting_room: Annotated[MeetingRoom, "The name of the meeting room."] = MeetingRoom.VIRTUAL,
-    time_slot: Annotated[Optional[str], "Time of the meeting (e.g., '14:00'-'15:00'). Immediate schedule if value not provided."] = "Now"):
+    time_slot: Annotated[Optional[str], "Time of the meeting (e.g., '14:00'-'15:00'). Immediate schedule if value not provided."] = "Now",
+    ):
     """Schedules meeting for a given list of attendees at a given time and date"""
+    meet_id = str(uuid.uuid4())[:5]
 
-    response_message = f"Meeting with Topic: '{topic}' is successfully scheduled. \n\n"
-    response_message += f"**Meeting Details**:\nAttendees: {attendees}.\nMeeting room: {meeting_room.value}\nDate: {date}\nTime slot: {time_slot}"
+    if tool_ctx:
+        meeting_details = {
+            "meet_id": meet_id,
+            "attendees": attendees,
+            "topic": topic,
+            "date": date,
+            "meeting_room": meeting_room,
+            "time_slot": time_slot
+        }
+        # Update the state with these new values
+        # There are a lot of ways to customize this
+        tool_ctx.update(**meeting_details)
+        print(f"Current State: {tool_ctx.dump_state()}")
+
+    response_message = f"Meeting with Topic: '{topic}' is successfully scheduled with ID {meet_id}. \n\n"
+    response_message += f"**Meeting Details**:\nAttendees: {attendees}.\nMeeting room: {meeting_room}\nDate: {date}\nTime slot: {time_slot}"
 
     return response_message
 
 @function_tool
-def cancel_meet_tool(meet_id: Annotated[str, "The id of the meeting to cancel in lower case"]):
+def cancel_meet_tool(meet_id: Annotated[str, "The id of the meeting to cancel in lower case"],
+                     tool_ctx: ToolContext):
     """Cancels the meeting with the given ID"""
 
-    if meet_id.startswith("a"):
-        response_message = f"Successfully cancelled meeting with ID: {meet_id}"
-        return response_message
-    if meet_id.startswith("b"):
-        response_message = "The meeting is currently in progress, unable to cancel this meeting."
-        return response_message
-
-    return "An error occurred while cancelling the meeting. Please make sure meeting ID is valid."
+    try:
+        if tool_ctx.get("meet_id") == meet_id:
+            # We can add more logic here, but keeping it simple for now
+            print(f"Current State: {tool_ctx.dump_state()}")
+            return f"Successfully cancelled meeting with ID: {meet_id}"
+        else:
+            return f"Meeting with ID: {meet_id} does not exist."
+    except Exception as e:
+        print(f"Error occured when canceling a meeting. {str(e)}")
+        return "An error occurred while cancelling the meeting. Please make sure meeting ID is valid."
 
 @function_tool
 async def get_current_time(country: Annotated[str, "Name of the country"]) -> dict:


### PR DESCRIPTION
Resolves #48 
Changelog:
1. Add basic state management for the live api boilerplate.
2. Added `ToolContext` a dict management class which handles setting, getting and clearing of the dict access to the high level functions in `tool_context.py`.
3. Functions can now read and update the shared tool context which is created per websocket session.
   - If they accept a `ToolContext` we ignore this argument when creating the function declaration using `@function_tool`.
   - If a function needs to use the tool context, it should define the tool context as a Mandatory Argument, not Optional.
5. Updated `app.py` to send the tool context each time when a function call is invoked. 
    - Inside the `call_function` we check if the function being called uses the `ToolContext` by calling `accepts_tool_context` and then update the args accordingly to send the current context along with the existing args provided by the llm.